### PR TITLE
If paper exists, updating notes/tags rather than adding a new entry

### DIFF
--- a/background.js
+++ b/background.js
@@ -204,7 +204,7 @@ function savePaperToDatabase(paperData, callback) {
     
     // Save back to storage
     chrome.storage.local.set({ papers: papers }, () => {
-      callback({ success: true, paperCount: papers.length });
+      callback({ success: true, paperCount: papers.length, savedPaper: paperWithMeta });
     });
   });
 }

--- a/content.js
+++ b/content.js
@@ -573,7 +573,7 @@ function showPopupWithData(paperInfo, isExistingPaper = false) {
             });
           } else {
             // Save new paper if notes have been entered
-            if (notes.trim() !== '') {
+            if (notes.trim() !== '' || tags.length > 0) {
               chrome.runtime.sendMessage({
                 action: "fetchCitation",
                 title: paperInfo.title

--- a/content.js
+++ b/content.js
@@ -595,15 +595,24 @@ function showPopupWithData(paperInfo, isExistingPaper = false) {
                       // Update isExistingPaper so future edits are treated as updates
                       isExistingPaper = true;
                       // Update header to reflect that the paper is now saved
-                      // header.innerHTML = 'Paper Notes';
                       header.firstChild.textContent = 'Paper Notes';
-                      // closeButton.outerHTML = closeButton.outerHTML; // Re-create the button to reset event listeners
+
+                      paperInfo = { 
+                        ...saveResponse.savedPaper,  // Use the returned data
+                        notes: notes,
+                        tags: tags 
+                      };
+
                       const newCloseButton = closeButton.cloneNode(true);
                       closeButton.parentNode.replaceChild(newCloseButton, closeButton);
                       newCloseButton.addEventListener('click', () => popup.remove());
                       popup.querySelector('.popup-header button').addEventListener('click', () => popup.remove());
                       // Update our local reference to paperInfo to include the new ID
-                      paperInfo = { ...paperData, id: Date.now().toString() };
+                      paperInfo = { 
+                        ...saveResponse.savedPaper,  // Contains correct ID from background
+                        notes: notes,
+                        tags: tags
+                      };
                     } else {
                       updateStatus("Error saving paper", true);
                     }


### PR DESCRIPTION
Feel free to merge if you also find it useful.

If we want to update notes/tags, e.g., remove "to read" after reading while still keeping the paper, we have to save the paper again and remove the old entry. I add some code so that we can **update** notes/tags for existing paper.

The system will now:

- Show existing notes/tags when re-saving a paper

- Update existing entries instead of creating duplicates

- Provide clear visual feedback about update/save state

- Refresh the library list after updates

Some additional changes:

- Fix bug: when using popup to save a new paper, notes are saved successfully, but tags aren't. Tags can be saved only when reopen the popup. Not sure if it's because of the new feature. 
- In the popup, when note is empty, editing tags also triggers saving
